### PR TITLE
Sub variable expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ Use fancy operators in assignment.
 {% assign title_text += ' →' if linkpost %}
 ```
 
+Use variables in assignment.
+
+```
+{% assign my_data = site.data.{{ data_file_name }} %}
+{% assign name = site.name | append:page.{{ product_name }} | downcase %}
+{% assign stupid_example = (page.{{ product_name }} == null ? 'no-product' : 'product-{{ page.product_code }} | downcase }}') %}
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/octopress/assign-tag/fork )

--- a/lib/octopress-assign-tag.rb
+++ b/lib/octopress-assign-tag.rb
@@ -25,22 +25,20 @@ module Octopress
             value    = $3
 
             if value =~ VAR_MATCH 
-              firstPart = $1
-              evaluatePart = $2
-              lastPart = $4
-              newValue = ""
+              first_part = $1
+              evaluate_part = $2
+              last_part = $4
+              new_value = ""
 
-              evaluatePart.scan (SUB_VARS) {
-                preValue = $1
-                evaluatedVar = TagHelpers::Var.get_value($3, context)
-                newValue = newValue + preValue + evaluatedVar
-                print newValue
+              evaluate_part.scan (SUB_VARS) {
+                pre_value = $1
+                evaluated_var = TagHelpers::Var.get_value($3, context)
+                new_value = new_value + pre_value + evaluated_var
+                print new_value
               }
-              value = firstPart + newValue + lastPart
-              tempvalue = TagHelpers::Var.get_value(value, context)
-              context = TagHelpers::Var.set_var(var, '=', tempvalue, context)
-              return
+              value = first_part + new_value + last_part
             end
+            
             value = TagHelpers::Var.get_value(value, context)
 
             return if value.nil?

--- a/lib/octopress-assign-tag.rb
+++ b/lib/octopress-assign-tag.rb
@@ -34,11 +34,10 @@ module Octopress
                 pre_value = $1
                 evaluated_var = TagHelpers::Var.get_value($3, context)
                 new_value = new_value + pre_value + evaluated_var
-                print new_value
               }
               value = first_part + new_value + last_part
             end
-            
+
             value = TagHelpers::Var.get_value(value, context)
 
             return if value.nil?

--- a/lib/octopress-assign-tag/version.rb
+++ b/lib/octopress-assign-tag/version.rb
@@ -1,7 +1,7 @@
 module Octopress
   module Tags
     module Assign
-      VERSION = "1.0.3"
+      VERSION = "1.0.4"
     end
   end
 end

--- a/test/_expected/index.html
+++ b/test/_expected/index.html
@@ -28,7 +28,8 @@ hello → hello
 HELLO → HELLO
 hello-goodbye → hello-goodbye
 HELLO-GOODBYE → HELLO-GOODBYE
-complex-hello-goodbye → COMPLEX-HELLO-GOODBYE
+COMPLEX-HELLO-GOODBYE → COMPLEX-HELLO-GOODBYE
+complex-hello-GOODBYE → complex-hello-GOODBYE
 
 ## Filters on non-string variables
 ABab

--- a/test/_expected/index.html
+++ b/test/_expected/index.html
@@ -21,5 +21,14 @@ awesome → awesome
 AWESOME → AWESOME
 whatever-man → whatever-man
 
+## Assignment with sub variables
+sub_var1 → sub_var1
+sub_var2 → sub_var2
+hello → hello
+HELLO → HELLO
+hello-goodbye → hello-goodbye
+HELLO-GOODBYE → HELLO-GOODBYE
+complex-hello-goodbye → COMPLEX-HELLO-GOODBYE
+
 ## Filters on non-string variables
 ABab

--- a/test/index.html
+++ b/test/index.html
@@ -1,6 +1,8 @@
 ---
 layout: null
 test_array: [a, b, A, B]
+sub_var1: hello
+sub_var2: goodbye
 ---
 ## Simple assign
 yep → {% assign var1 = 'yep' %}{{ var1 }}
@@ -24,6 +26,15 @@ yepyep → {% assign var1 += 'yep' %}{{ var1 }}
 awesome → {% assign var9 = (page.layout == null ? 'awesome' : 'lame' ) %}{{ var9 }}
 AWESOME → {% assign var10 = var9 | upcase %}{{ var10 }}
 whatever-man → {% assign var11 = 'whatever man' || nil | replace:' ','-' %}{{ var11 }}
+
+## Assignment with sub variables
+sub_var1 → {% assign test_var1 = 'sub_var1' %}{{ test_var1 }}
+sub_var2 → {% assign test_var2 = 'sub_var2' %}{{ test_var2 }}
+hello → {% assign var12 = page.{{ test_var1 }} %}{{ var12 }}
+HELLO → {% assign var13 = page.{{ test_var1 }} | upcase %}{{ var13 }}
+hello-goodbye → {% assign var15 = page.{{ test_var1 }} | append:'-' | append:page.{{ test_var2 }} %}{{ var15 }}
+HELLO-GOODBYE → {% assign var16 = page.{{ test_var1 }} | append:'-' | append:page.{{ test_var2 }} | upcase %}{{ var16 }}
+complex-hello-goodbye → {% assign var17 = (page.{{ test_var1 }} != null ? 'complex-{{ page.sub_var1 }}-{{ page.sub_var2 }}' : 'lame' ) | upcase %}{{ var17 }}
 
 ## Filters on non-string variables
 {% assign items = page.test_array | sort %}{{ items }}

--- a/test/index.html
+++ b/test/index.html
@@ -34,7 +34,8 @@ hello → {% assign var12 = page.{{ test_var1 }} %}{{ var12 }}
 HELLO → {% assign var13 = page.{{ test_var1 }} | upcase %}{{ var13 }}
 hello-goodbye → {% assign var15 = page.{{ test_var1 }} | append:'-' | append:page.{{ test_var2 }} %}{{ var15 }}
 HELLO-GOODBYE → {% assign var16 = page.{{ test_var1 }} | append:'-' | append:page.{{ test_var2 }} | upcase %}{{ var16 }}
-complex-hello-goodbye → {% assign var17 = (page.{{ test_var1 }} != null ? 'complex-{{ page.sub_var1 }}-{{ page.sub_var2 }}' : 'lame' ) | upcase %}{{ var17 }}
+COMPLEX-HELLO-GOODBYE → {% assign var17 = (page.{{ test_var1 }} == 'hello' ? 'complex-{{ page.sub_var1 }}-{{ page.sub_var2 }}' : 'lame' ) | upcase %}{{ var17 }}
+complex-hello-GOODBYE → {% assign var17 = (page.{{ test_var1 }} == null ? 'lame' : 'complex-{{ page.sub_var1 }}-{{ page.sub_var2 | upcase }}') %}{{ var17 }}
 
 ## Filters on non-string variables
 {% assign items = page.test_array | sort %}{{ items }}


### PR DESCRIPTION
Allows for variables to be embedded into the right side of the assign and be evaluated before the actual assign. For instance if I have an existing variable `product_code`, I can do the following:

```
{% assign product_data = site.data.{{ product_code }} %}
```

More than a single variable can be embedded.
